### PR TITLE
feat: Finalize project with corrected install script

### DIFF
--- a/PROXY_README.md
+++ b/PROXY_README.md
@@ -45,7 +45,7 @@ This architecture decouples the core Xinput functionality from the networking, m
     sudo ./install-service.sh
     ```
 
-    This script will compile both proxy versions, automatically detect your system's architecture (e.g., `x86_64` or `aarch64`), and install the correct binary. It also copies the service file to `/etc/systemd/system` and enables the service to run automatically in the background.
+    This script automatically detects your system's architecture (e.g., `x86_64` or `aarch64`) and installs the correct pre-compiled binary from the package. It also copies the service file to `/etc/systemd/system` and enables the service to run automatically in the background.
 
 3.  **Verify the Service (Optional):** You can check if the service is running correctly with:
     ```bash


### PR DESCRIPTION
This commit finalizes the project by correcting a major flaw in the deployment process and ensuring the release pipeline is robust.

The `install-service.sh` script has been updated to remove the compilation step. It now correctly assumes it is running from a package containing pre-compiled binaries and installs the correct one based on the system's architecture. This makes the installation process more reliable and removes the need for build tools on the target machine.

This completes the full feature set, including:
- A C-based, cross-compiled UDP proxy.
- An Android app with the new `com.nanofuxion.xinputbridge` package name.
- A fully automated release pipeline with version management.
- Comprehensive documentation for the new proxy-based architecture.